### PR TITLE
Fix: clear context to avoid [belongerr] when Spark return [error]

### DIFF
--- a/src/bots/SparkBot.js
+++ b/src/bots/SparkBot.js
@@ -86,11 +86,14 @@ export default class SparkBot extends Bot {
           );
 
           let text = "";
+          let error = false;
           source.addEventListener("message", (event) => {
             if (event.data === "<end>") {
               onUpdateResponse(callbackParam, { done: true });
               source.close();
               resolve();
+            } else if (event.data === "[error]") {
+              error = true;
             } else if (event.data.slice(-5) === "<sid>") {
               // ignore <sid> message
               return;
@@ -111,6 +114,11 @@ export default class SparkBot extends Bot {
               }
               text += partialText;
               onUpdateResponse(callbackParam, { content: text, done: false });
+
+              // clear context if error
+              if (error) {
+                this.setChatContext(null);
+              }
             }
           });
 


### PR DESCRIPTION
This PR aims to address the [belongerr] issue of SparkBot in #633 

The reason to clear context is Spark will make the current conversation unusable for sensitive message
![WX20231125-160349@2x](https://github.com/sunner/ChatALL/assets/2755122/704bfc70-99ee-41c2-99bf-4e5b1ec50784)

so I choose to clear context whenever encoutering this situation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved error handling in the SparkBot's message processing, ensuring better response management during issues.
	- Enhanced chat context management by resetting it in case of errors, leading to a more reliable user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->