### PR TITLE
Fix: refresh context for UnauthorizedRequest from Bing

### DIFF
--- a/src/bots/microsoft/BingChatBot.js
+++ b/src/bots/microsoft/BingChatBot.js
@@ -181,7 +181,10 @@ export default class BingChatBot extends Bot {
               } else if (event.type === 2) {
                 if (event.item.result.value !== "Success") {
                   console.error("Error sending prompt to Copilot:", event);
-                  if (event.item.result.value === "InvalidSession") {
+                  if (
+                    event.item.result.value === "InvalidSession" ||
+                    event.item.result.value === "UnauthorizedRequest"
+                  ) {
                     // Create a new conversation and retry
                     context = await this.createChatContext();
                     this.setChatContext(context);


### PR DESCRIPTION
Resolve #629 

 When token is expired, Bing will return such message
`{"type":2,"invocationId":"1","item":{"firstNewMessageIndex":null,"defaultChatName":null,"result":{"value":"UnauthorizedRequest","message":"Token issued by https://sydney.bing.com/sydney is invalid (IDX10223: Lifetime validation failed. The token is expired. ValidTo (UTC): '12/8/2023 3:48:23 AM', Current time (UTC): '12/8/2023 3:58:42 AM'.)","error":"UnauthorizedRequest","renewCert":true,"serviceVersion":"20231207.96"}}}`

There should be other scenarios for `UnauthorizedRequest`, I'm not sure whether it's appropriate to use it for direct comparison, what is your opinion ? @sunner 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Enhanced error handling for the Bing Chat Bot to address "InvalidSession" and "UnauthorizedRequest" responses, allowing for automatic retries in these scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->