### PR TITLE
Restrict the max height of ChatResponse

### DIFF
--- a/src/components/Messages/ChatResponse.vue
+++ b/src/components/Messages/ChatResponse.vue
@@ -617,4 +617,9 @@ function pageRight() {
 .cursor-auto {
   cursor: auto;
 }
+
+.v-md-editor-preview {
+    max-height: 50vh;
+    overflow-y: overlay;
+}
 </style>


### PR DESCRIPTION
There is no limit to the current response height, so when some Bots reply with little content, there will be a lot of blank space under a Bot, which is inconvenient for reading. Therefore, a maximum height limit is added.

**Before:**
![image](https://github.com/user-attachments/assets/2e2e39fd-ed93-446d-82e5-278b2d08fc30)

**After:**
![image](https://github.com/user-attachments/assets/fa9cc29b-105f-4a52-994d-a63341dc28ef)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new CSS class to enhance the styling of the Markdown editor preview, improving its height and overflow behavior for better user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->