### PR TITLE
Format `src/bots/openai/ChatGPTBot.js`

### DIFF
--- a/src/bots/openai/ChatGPTBot.js
+++ b/src/bots/openai/ChatGPTBot.js
@@ -41,9 +41,7 @@ export default class ChatGPTBot extends Bot {
     let available = false;
 
     try {
-      const response = await axios.get(
-        "https://chatgpt.com/api/auth/session",
-      );
+      const response = await axios.get("https://chatgpt.com/api/auth/session");
       if (!response.data?.error && response.data?.accessToken) {
         this.accessToken = response.data.accessToken;
         available = true;
@@ -214,16 +212,13 @@ export default class ChatGPTBot extends Bot {
 
     return new Promise((resolve, reject) => {
       try {
-        const source = new SSE(
-          "https://chatgpt.com/backend-api/conversation",
-          {
-            headers: {
-              ...headers,
-              accept: "text/event-stream",
-            },
-            payload,
+        const source = new SSE("https://chatgpt.com/backend-api/conversation", {
+          headers: {
+            ...headers,
+            accept: "text/event-stream",
           },
-        );
+          payload,
+        });
 
         let preInfo = [];
         source.addEventListener("message", (event) => {


### PR DESCRIPTION
Use `npm run lint`/`vue-cli-service lint` to format the code.

Related to #914 / 3675a9415ab1d0e9407ae10be083d8cd4cc297eb

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Improved code formatting for the API request process in the ChatGPT Bot, enhancing readability without affecting functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->