### PR TITLE
Add missing xAI Grok info in README.md, cc #942

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ Typical users of ChatALL are:
 | [Tongyi Qianwen](http://tongyi.aliyun.com/)                                    | Yes         | Coming soon |                                             |
 | [Vicuna 13B & 33B](https://lmsys.org/blog/2023-03-30-vicuna/)                  | Yes         | No API      | No Login required                           |
 | [WizardLM 70B](https://github.com/nlpxucan/WizardLM)                           | Yes         | No API      |                                             |
+| [xAI Grok](https://x.ai)                                                       | No          | Yes         |                                             |
 | [YouChat](https://you.com/)                                                    | Yes         | No API      |                                             |
 | [You](https://you.com/)                                                        | Yes         | No API      |                                             |
 | [Zephyr](https://huggingface.co/spaces/HuggingFaceH4/zephyr-chat)              | Yes         | No API      |                                             |


### PR DESCRIPTION
It's just one of my stupid mistakes that needs to be fixed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated README with new AI bot "xAI Grok"
	- Added details about xAI Grok's API and web access capabilities

<!-- end of auto-generated comment: release notes by coderabbit.ai -->