### PR TITLE
Change the default bots to those bots using API, cc #953

### DIFF
--- a/src/store/chats.js
+++ b/src/store/chats.js
@@ -16,14 +16,14 @@ class Chats {
         await Chats.add({
           favBots: [
             // default bots
-            { classname: "ChatGPT35Bot", selected: true },
-            { classname: "ChatGPT4Bot", selected: true },
-            { classname: "BingChatCreativeBot", selected: true },
-            { classname: "BingChatBalancedBot", selected: true },
-            { classname: "BingChatPreciseBot", selected: true },
-            { classname: "BardBot", selected: true },
-            { classname: "ClaudeInstantPoeBot", selected: true },
-            { classname: "FalconHC180bBot", selected: true },
+            { classname: "AzureOpenAIAPIBot", selected: false },
+            { classname: "ClaudeAPISonnetBot", selected: false },
+            { classname: "Gemini15ProAPIBot", selected: false },
+            { classname: "Gemma29bGroqAPIBot", selected: false },
+            { classname: "Grok2APIBot", selected: false },
+            { classname: "Llama370bGroqAPIBot", selected: false },
+            { classname: "Mixtral8x7bGroqAPIBot", selected: false },
+            { classname: "OpenAIAPI4oBot", selected: false },
           ],
         }),
       );


### PR DESCRIPTION
This pull request makes changes to the default bots in the `Chats` class within the `src/store/chats.js` file. The most important change involves replacing the existing all web-based and non-working default bots with a new set of API bots.

Changes to default bots:

* [`src/store/chats.js`](diffhunk://#diff-606a00564952231fc00e99986b13ea98295fb732c4e5a26978ef51a19dfffe1fL19-R26): Replaced the previous default bots (e.g., `ChatGPT35Bot`, `ChatGPT4Bot`, `BingChatCreativeBot`, etc.) with new bots (e.g., `AzureOpenAIAPIBot`, `ClaudeAPISonnetBot`, `Gemini15ProAPIBot`, etc.) and set their `selected` status to `false`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Updated the default bot options available when starting a new chat session, providing a refreshed set of choices that are initially not pre-selected for improved user flexibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->