### PR TITLE
Allow blank GitHub issues, cc #458

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,1 +1,1 @@
-blank_issues_enabled: false
+blank_issues_enabled: true


### PR DESCRIPTION
It's inconvenient for professionals or power users, including me, as a volunteer maintainer. We don't have many issues to limit at the moment, so it's fine to allow blank issues. People can still choose the correct template, but we will have more flexibility here.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Issue submissions now allow blank entries, offering users increased flexibility when reporting issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->