### PR TITLE
Avoid sending temperature for OpenAI reasoning models

### DIFF
--- a/src/bots/openai/OpenAIAPIBot.js
+++ b/src/bots/openai/OpenAIAPIBot.js
@@ -29,7 +29,9 @@ export default class OpenAIAPIBot extends LangChainBot {
       },
       openAIApiKey: store.state.openaiApi.apiKey,
       modelName: this.constructor._model ? this.constructor._model : "",
-      temperature: store.state.openaiApi.temperature,
+      temperature: this.constructor._model.startsWith("o")
+        ? undefined
+        : store.state.openaiApi.temperature,
       streaming: true,
     });
     return chatModel;


### PR DESCRIPTION
Only omit temperature for models starting with "o" to prevent API errors

Fix #995

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved model configuration to handle temperature settings more accurately based on the model name, ensuring better compatibility with certain models.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->