### PR TITLE
Update Grok 3 series model, remove `-beta` suffix

### DIFF
--- a/src/bots/xai/Grok3APIBot.js
+++ b/src/bots/xai/Grok3APIBot.js
@@ -3,7 +3,7 @@ import xAIAPIBot from "./xAIAPIBot";
 export default class Grok3APIBot extends xAIAPIBot {
   static _className = "Grok3APIBot";
   static _logoFilename = "grok-3-logo.png";
-  static _model = "grok-3-beta";
+  static _model = "grok-3";
   constructor() {
     super();
   }

--- a/src/bots/xai/Grok3MiniAPIBot.js
+++ b/src/bots/xai/Grok3MiniAPIBot.js
@@ -3,7 +3,7 @@ import xAIAPIBot from "./xAIAPIBot";
 export default class Grok3MiniAPIBot extends xAIAPIBot {
   static _className = "Grok3MiniAPIBot";
   static _logoFilename = "grok-3-mini-logo.png";
-  static _model = "grok-3-mini-beta";
+  static _model = "grok-3-mini";
   constructor() {
     super();
   }

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -318,8 +318,8 @@
   "xaiApi": {
     "name": "xAI API",
     "grok-2-latest": "Grok-2",
-    "grok-3-beta": "Grok 3",
-    "grok-3-mini-beta": "Grok 3 Mini"
+    "grok-3": "Grok 3",
+    "grok-3-mini": "Grok 3 Mini"
   },
   "updates": {
     "updateAvailable": "Update verfügbar!",

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -321,8 +321,8 @@
   "xaiApi": {
     "name": "xAI API",
     "grok-2-latest": "Grok-2",
-    "grok-3-beta": "Grok 3",
-    "grok-3-mini-beta": "Grok 3 Mini"
+    "grok-3": "Grok 3",
+    "grok-3-mini": "Grok 3 Mini"
   },
   "updates": {
     "updateAvailable": "Update Available!",

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -318,8 +318,8 @@
   "xaiApi": {
     "name": "xAI API",
     "grok-2-latest": "Grok-2",
-    "grok-3-beta": "Grok 3",
-    "grok-3-mini-beta": "Grok 3 Mini"
+    "grok-3": "Grok 3",
+    "grok-3-mini": "Grok 3 Mini"
   },
   "updates": {
     "updateAvailable": "¡Hay una actualización disponible!",

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -318,8 +318,8 @@
   "xaiApi": {
     "name": "xAI API",
     "grok-2-latest": "Grok-2",
-    "grok-3-beta": "Grok 3",
-    "grok-3-mini-beta": "Grok 3 Mini"
+    "grok-3": "Grok 3",
+    "grok-3-mini": "Grok 3 Mini"
   },
   "updates": {
     "updateAvailable": "Mise à jour disponible !",

--- a/src/i18n/locales/it.json
+++ b/src/i18n/locales/it.json
@@ -320,8 +320,8 @@
   "xaiApi": {
     "name": "xAI API",
     "grok-2-latest": "Grok-2",
-    "grok-3-beta": "Grok 3",
-    "grok-3-mini-beta": "Grok 3 Mini"
+    "grok-3": "Grok 3",
+    "grok-3-mini": "Grok 3 Mini"
   },
   "updates": {
     "updateAvailable": "Aggiornamento disponibile!",

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -318,8 +318,8 @@
   "xaiApi": {
     "name": "xAI API",
     "grok-2-latest": "Grok-2",
-    "grok-3-beta": "Grok 3",
-    "grok-3-mini-beta": "Grok 3 Mini"
+    "grok-3": "Grok 3",
+    "grok-3-mini": "Grok 3 Mini"
   },
   "updates": {
     "updateAvailable": "新しいバージョンが利用可能です。",

--- a/src/i18n/locales/ko.json
+++ b/src/i18n/locales/ko.json
@@ -321,8 +321,8 @@
   "xaiApi": {
     "name": "xAI API",
     "grok-2-latest": "Grok-2",
-    "grok-3-beta": "Grok 3",
-    "grok-3-mini-beta": "Grok 3 Mini"
+    "grok-3": "Grok 3",
+    "grok-3-mini": "Grok 3 Mini"
   },
   "updates": {
     "updateAvailable": "업데이트 가능!",

--- a/src/i18n/locales/ru.json
+++ b/src/i18n/locales/ru.json
@@ -318,8 +318,8 @@
   "xaiApi": {
     "name": "xAI API",
     "grok-2-latest": "Grok-2",
-    "grok-3-beta": "Grok 3",
-    "grok-3-mini-beta": "Grok 3 Mini"
+    "grok-3": "Grok 3",
+    "grok-3-mini": "Grok 3 Mini"
   },
   "updates": {
     "updateAvailable": "Доступно обновление!",

--- a/src/i18n/locales/vi.json
+++ b/src/i18n/locales/vi.json
@@ -297,8 +297,8 @@
   "xaiApi": {
     "name": "xAI API",
     "grok-2-latest": "Grok-2",
-    "grok-3-beta": "Grok 3",
-    "grok-3-mini-beta": "Grok 3 Mini"
+    "grok-3": "Grok 3",
+    "grok-3-mini": "Grok 3 Mini"
   },
   "updates": {
     "updateAvailable": "Cập nhập mới đã có!",

--- a/src/i18n/locales/zh.json
+++ b/src/i18n/locales/zh.json
@@ -318,8 +318,8 @@
   "xaiApi": {
     "name": "xAI API",
     "grok-2-latest": "Grok-2",
-    "grok-3-beta": "Grok 3",
-    "grok-3-mini-beta": "Grok 3 Mini"
+    "grok-3": "Grok 3",
+    "grok-3-mini": "Grok 3 Mini"
   },
   "updates": {
     "updateAvailable": "有更新!",

--- a/src/i18n/locales/zhtw.json
+++ b/src/i18n/locales/zhtw.json
@@ -318,8 +318,8 @@
   "xaiApi": {
     "name": "xAI API",
     "grok-2-latest": "Grok-2",
-    "grok-3-beta": "Grok 3",
-    "grok-3-mini-beta": "Grok 3 Mini"
+    "grok-3": "Grok 3",
+    "grok-3-mini": "Grok 3 Mini"
   },
   "updates": {
     "updateAvailable": "有新版可使用！",


### PR DESCRIPTION
xAI just updated the model and dropped the `-beta` suffix from the model ID.

Looks like there’s no official announcement yet, but I’ve shared some findings here: x.com/PeterDaveHello/status/1924872013619069422

---

Summary from GitHub Copilot:

> 
> This pull request updates the `Grok-3` and `Grok-3 Mini` models from their beta versions to their stable versions and ensures consistency across the codebase and localization files. Below is a summary of the most important changes:
> 
> ### Model Updates:
> * Updated the `_model` property in `Grok3APIBot` from `"grok-3-beta"` to `"grok-3"` (`src/bots/xai/Grok3APIBot.js`).
> * Updated the `_model` property in `Grok3MiniAPIBot` from `"grok-3-mini-beta"` to `"grok-3-mini"` (`src/bots/xai/Grok3MiniAPIBot.js`).
> 
> ### Localization Updates:
> * Replaced `"grok-3-beta"` with `"grok-3"` and `"grok-3-mini-beta"` with `"grok-3-mini"` in the following localization files:
>   - German (`src/i18n/locales/de.json`).
>   - English (`src/i18n/locales/en.json`).
>   - Spanish (`src/i18n/locales/es.json`).
>   - French (`src/i18n/locales/fr.json`).
>   - Italian (`src/i18n/locales/it.json`).
>   - Japanese (`src/i18n/locales/ja.json`).
>   - Korean (`src/i18n/locales/ko.json`).
>   - Russian (`src/i18n/locales/ru.json`).
>   - Vietnamese (`src/i18n/locales/vi.json`).
>   - Simplified Chinese (`src/i18n/locales/zh.json`).
>   - Traditional Chinese (`src/i18n/locales/zhtw.json`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Updated model identifiers by removing the "-beta" suffix from Grok 3 and Grok 3 Mini across the app.
- **Documentation**
  - Updated localization keys in all supported languages to reflect the new model identifiers, ensuring consistent naming in the interface. No changes to display names or translations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->